### PR TITLE
fixed the case when component is not present in master process. The bug ...

### DIFF
--- a/lib/component-status.js
+++ b/lib/component-status.js
@@ -46,6 +46,12 @@ var ComponentStatus = exports.ComponentStatus = function(emitter){
 
 	this.emitter = emitter;
 	emitter.on('new-component-status', function(component){
+		if (component.worker !== process.pid && cluster.isMaster) {
+
+			if (!components[component.name] && component.loader) {
+				require(component.loader.path).load.apply(null, component.loader.args);		
+			}
+		}
 
 		//console.log('[cluster2] master component-status:' + JSON.stringify(component));
 		components[component.name] = {
@@ -73,13 +79,14 @@ var ComponentStatus = exports.ComponentStatus = function(emitter){
 };
 
 //worker
-ComponentStatus.prototype.register = function(name, handler, reducer, updater){
+ComponentStatus.prototype.register = function(name, handler, reducer, updater, loader){
 
 	var emitter = this.emitter;
 	emitter.emit('new-component-status', {
 		'name' : name,
 		'reducer': reducer,
-		'worker': process.pid
+		'worker': process.pid,
+		'loader': loader
 	});
 
 	emitter.on('get-component-status', function(component, now, options){
@@ -243,7 +250,7 @@ if(process.cluster && process.cluster.clustered){
 					});
 				}
 				catch(error){
-					console.log('[cluster2] master sending to worker failed');
+					console.log('[cluster2] master sending to worker failed: ' + error);
 				}
 			});
 


### PR DESCRIPTION
...would lead to unability to sync state across workers and master and los of state when a worker dies/recycled.

Introduced: loader that would be used in case component has not been already loaded.
The loader expects:
- path is absolute path to loader file
- args is arguments used to create component
- implements load(arg1, arg2 …) function
