### PR TITLE
+ warmup enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ listen({
 		//warm up your application, must return value or promise
 		return app;
 	},
+	'warmUpPort': 9093, //the port to do warmup, after which, server will be stopped, and restarted on the actual port
 	'debug': { //node-inspector integration
 		'webPort': 9092, //node-inspector web listening port
 		'saveLiveEdit': true
@@ -84,9 +85,11 @@ The flow is as the following:
 * worker starts `listen`
 * worker configures `app` with given `configureApp`
 * worker creates server using `createServer` and takes in configured `app`
-* worker starts server on `port` and wait for `listening` event
+* worker starts server on `warmUpPort` and wait for `listening` event
 * worker receives `listening` event and starts `warmup`
-* worker waits for `warmup` to complete and notify master that it's ready to serve traffic
+* worker waits for `warmup` to complete and stops the warmup server
+* worker starts server on actual `port` and wait for `listening` event
+* worker receives `listening` event and notify master that it's ready to serve traffic
 * worker resolves the `promise` returned by `listen`
 * master receives notifications from all workers then mark up `ecv`
 * master then resolves the `promise` returned by `listen` 

--- a/lib/index.js
+++ b/lib/index.js
@@ -123,6 +123,7 @@ module.exports = {
                 'monCreateServer': require('./monitor').monCreateServer,
                 'monApp': require('./monitor').monApp,
                 'monPort': argv.monPort || 8081,
+                'warmUpPort': argv.warmUpPort || 8083,
                 'monConfigureApp': function(monApp){
 
                     return monApp;

--- a/lib/master.js
+++ b/lib/master.js
@@ -37,6 +37,7 @@ Master.prototype.initialize = function(proc, options){
 			'createServer': options.monCreateServer,
 			'app': options.monApp,
 			'port': options.monPort,
+            'warmUpPort': options.warmUpPort,
 			'ecv': options.ecv,
 			'cache': options.cache,
 			'gc': options.gc,
@@ -49,6 +50,7 @@ Master.prototype.initialize = function(proc, options){
 				when.all([
 					utils.rejectIfPortBusy('localhost', options.port), 
 					utils.rejectIfPortBusy('localhost', options.monPort),
+                    utils.rejectIfPortBusy('localhost', options.warmUpPort),
 					utils.rejectIfPortBusy('localhost', _this['debug.debugPort']),
 					utils.rejectIfPortBusy('localhost', _this['debug.webPort'])
 				])
@@ -86,12 +88,16 @@ Master.prototype.initialize = function(proc, options){
 					//cluster#setupMaster or 'settings' could only handle execArgv, and won't help with '--nouse-idle-notification'
 				}
 
-				_.each(_.range(0, _this.noWorkers), function(ith){
-					return _this.fork(_this.options);
-				});
+                utils.pickAvailablePorts(options.warmUpPort, options.warmUpPort + _this.noWorkers * 3, _this.noWorkers).then(function(warmUpPorts){
+                    _.each(_.range(0, _this.noWorkers), function(ith){
+                        _this.options.warmUpPort = warmUpPorts.shift();
+                        _this.logger.info('[master] pick up warmup port:%d', _this.options.warmUpPort);
+                        return _this.fork(_this.options);
+                    });
+                });
 
 				//wait for all puppets to be ready, and then enable ECV as the last step
-				return utils.warmUpThenMark(_this.emitter, 
+				return utils.markUpAfterAllListening(_this.emitter, 
 						_.map(_this.puppets, function(p){
 							return p.pid;
 						}))
@@ -149,8 +155,8 @@ Master.prototype.initialize = function(proc, options){
 			_this.puppets[worker.process.pid].whenOnline();
 		});
 
-		cluster.on('listening', function(worker){
-			_this.puppets[worker.process.pid].whenListening();
+		cluster.on('listening', function(worker, address){
+			_this.puppets[worker.process.pid].whenListening(address);
 		});
 
 		cluster.on('exit', function(worker){
@@ -229,13 +235,13 @@ Master.prototype.listen = function(){
 
 	when(configureApp(monApp)).ensure(function(configured){
 
-		var server = createServer(monApp).listen(monPort, function(){
+		var server = createServer(monApp).listen(monPort, function(address){
 			
 			_this.logger.info('[master] warmUp');
 
-			when(warmUp()).ensure(function(warmedUp){
+			when(warmUp(monApp, address)).ensure(function(){
 
-				_this.logger.info('[master] warmUp complete: %j', warmedUp);
+				_this.logger.info('[master] warmUp complete');
 
 				tillListen.resolve({
 					'server': server,

--- a/lib/puppet.js
+++ b/lib/puppet.js
@@ -21,6 +21,8 @@ var Puppet = exports.Puppet = function Puppet(master, worker, options, env){
 		'emitter': master.emitter,
 		'cacheManager': env.CACHE_MANAGER,
 		'debugging': env.debug,
+        'port': options.port,
+        'warmUpPort': options.warmUpPort,
 		'worker': worker,
 		'lastHeartbeat': Date.now()
 	});
@@ -48,9 +50,11 @@ var Puppet = exports.Puppet = function Puppet(master, worker, options, env){
 			}
 		},
 
-		'whenListening': function(){
-
-			_this.state = _this.activeState;
+		'whenListening': function(address){
+            
+            if(address.port === _this.port){
+                _this.state = _this.activeState;
+            }
 		},
 
 		'whenHeartbeat': function(){
@@ -226,14 +230,14 @@ Puppet.prototype.whenOnline = function(){
 	return this.state.whenOnline();
 };
 
-Puppet.prototype.whenListening = function(){
+Puppet.prototype.whenListening = function(address){
 
-	this.logger.info('[master] detects worker:%d is listening now', this.pid);
+	this.logger.info('[master] detects worker:%d is listening now on:%j', this.pid, address);
 
 	//this is mainly for the old worker to be notified that the successor is ready
     this.emitter.to(['master']).emit(util.format('worker-%d-listening', this.pid));
 
-	return this.state.whenListening();
+	return this.state.whenListening(address);
 };
 
 Puppet.prototype.whenHeartbeat = function(heartbeat){

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -327,9 +327,9 @@ exports.deathQueue = (function(){
 					var successor = success();
 
 					//when successor is in place, the old worker could be discontinued finally
-					emitter.once(util.format('worker-%d-warmup', successor.process.pid), function(){
+					emitter.once(util.format('worker-%d-listening', successor.process.pid), function(){
 
-						logger.debug('[deathQueue] successor:%d of %d warmup', successor.process.pid, pid);
+						logger.debug('[deathQueue] successor:%d of %d is ready', successor.process.pid, pid);
 
 						emitter.to(['master', pid]).emit('disconnect', pid);
 
@@ -403,18 +403,18 @@ exports.nanny = function nanny(puppets, queue, emitter, success, options){
 	});
 };
 
-exports.warmUpThenMark = function warmUpThenMark(emitter, expects){
+exports.markUpAfterAllListening = function markUpAfterAllListening(emitter, expects){
 
 	return when.map(expects, function(pid){
 
-		var tillWarmUp = when.defer();
+		var tillAllListening = when.defer();
 		
-		emitter.once(util.format('worker-%d-warmup', pid), function(pid){
+		emitter.once(util.format('worker-%d-listening', pid), function(pid){
 			
-			tillWarmUp.resolve(pid);
+			tillAllListening.resolve(pid);
 		});
 
-		return timeout(60000, tillWarmUp.promise);
+		return timeout(60000, tillAllListening.promise);
 	});
 };
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -22,6 +22,7 @@ var Worker = exports.Worker = function(proc, options){
 		'createServer': options.createServer,
 		'app': options.app,
 		'port': options.port,
+        'warmUpPort': options.warmUpPort,
 		'configureApp': function(app){
 
 			if(_.isFunction(app.use)){//make sure this middleware is ahead of others, to collect tps information
@@ -129,6 +130,7 @@ Worker.prototype.listen = function(){
 	var _this = this,
 		app = _this.app,
 		port = _this.port,
+        warmUpPort = _this.warmUpPort,
 		createServer = _this.createServer,
 		configureApp = _this.configureApp,
 		warmUp = _this.warmUp,
@@ -147,31 +149,39 @@ Worker.prototype.listen = function(){
 			when(configureApp(app)).ensure(function(configured){ //configure app before listening
 				
 				_this.logger.debug('[worker] %d app configured', _this.pid);
-					
-				var server = _this.server = createServer(app).listen(port, function(){
+                
+                var warmUpServer = createServer(app).listen(warmUpPort, function(address){
+                    
+                    _this.logger.info('[worker] %d started warming on:%d', _this.pid, warmUpPort);
+                    _this.emitter.to(['master', 'self']).emit(util.format('worker-%d-warming', _this.pid));
+                    
+                    when(warmUp(app, address)).ensure(function(){ //warm up app after listening
 
-					_this.logger.debug('[worker] %d started listening', _this.pid);
-					_this.emitter.to(['master', 'self']).emit(util.format('worker-%d-listening', _this.pid));
-					
-					//connection monitoring, including live/total connections and idle connections
-					server.on('connection', function(conn){
-						_this.whenConnected(conn);
+						_this.logger.info('[worker] %d warmed up', _this.pid);
+                        _this.emitter.to(['master', 'self']).emit(util.format('worker-%d-warmup', _this.pid)); //tell master i'm ready
+
+						warmUpServer.close(function(){
+                            
+                            var server = _this.server = createServer(app).listen(port, function(){
+                                _this.logger.info('[worker] %d started listening on:%d', _this.pid, port);
+					            _this.emitter.to(['master', 'self']).emit(util.format('worker-%d-listening', _this.pid));
+                                
+                                //connection monitoring, including live/total connections and idle connections
+                                server.on('connection', function(conn){
+                                    _this.whenConnected(conn);
+                                });
+                                
+                                tillListen.resolve({
+                                    'server': server,
+                                    'app': app,
+                                    'port': port,
+                                    'master': null,
+                                    'worker': _this
+                                });
+                            });
+                        });
 					});
-
-					when(warmUp(app)).ensure(function(warmedUp){ //warm up app after listening
-
-						_this.logger.debug('[worker] %d warmed up', _this.pid);
-						_this.emitter.to(['master', 'self']).emit(util.format('worker-%d-warmup', _this.pid)); //tell master i'm ready
-
-						tillListen.resolve({
-							'server': server,
-							'app': app,
-							'port': port,
-							'master': null,
-							'worker': _this
-						});
-					});
-				});
+                });
 			});
 		};
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     },
     "scripts": {
         "prestart": "rm -rf ./log; mkdir log; rm -rf ./pids; mkdir pids",
-        "start": "node ./examples/cluster-demo.js --port=9090 --monPort=9091 --noWorkers=1 --cache.enable --heartbeat.interval=5000 &",
+        "start": "node ./examples/cluster-demo.js --port=9090 --monPort=9091 --noWorkers=2 --cache.enable --heartbeat.interval=5000 &",
         "stop": "node shutdown.js",
         "pretest": "rm -rf ./log; mkdir log; rm -rf ./pids; mkdir pids",
         "test": "mocha --ui bdd --timeout 10s --reporter spec  ./test/*-test.js"

--- a/test/master-test.js
+++ b/test/master-test.js
@@ -24,7 +24,7 @@ describe('master', function(){
 			var logger = process.getLogger(),
 				Master = require('../lib/master').Master;
 
-			pickAvailablePorts(7000, 7999, 4).then(function(ports){
+			pickAvailablePorts(7000, 7999, 5).then(function(ports){
 
 				logger.info('[test] ports picked:%j', ports);
 
@@ -39,6 +39,7 @@ describe('master', function(){
 						'monApp': app,
 						'monPort': ports[0],
 						'port': ports[1],
+                        'warmUpPort': ports[4],
 						'noWorkers': 0,
 						'debug': {
 							'debugPort': ports[2],

--- a/test/puppet-test.js
+++ b/test/puppet-test.js
@@ -57,7 +57,9 @@ describe('puppet', function(){
                         });
                     }
                 },
-                puppet = new Puppet(master, worker, {}, {});
+                puppet = new Puppet(master, worker, {
+                        'port':8080
+                    }, {});
 
             master.puppets[pid] = puppet;
 
@@ -76,9 +78,9 @@ describe('puppet', function(){
                 puppet.whenOnline();
             });
 
-            emitter.once('listening', function(worker){
+            emitter.once('listening', function(worker, address){
 
-                puppet.whenListening();
+                puppet.whenListening(address);
             });
 
             emitter.once('heartbeat', function(worker, heartbeat){
@@ -119,7 +121,9 @@ describe('puppet', function(){
                     emitter.emit('exit', worker);
                 });
 
-                emitter.emit('listening', worker);
+                emitter.emit('listening', worker, {
+                    'port': 8080
+                });
             });
 
             emitter.emit('online', worker);

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -283,7 +283,7 @@ describe('utils', function(){
 
 				var successor = pid + 1;
 				process.nextTick(function(){
-					emitter.emit(util.format('worker-%d-warmup', successor));
+					emitter.emit(util.format('worker-%d-listening', successor));
 				});
 
 				return {
@@ -339,7 +339,7 @@ describe('utils', function(){
 
 						//because we queued the deaths, at the time this ith worker is to suicide, the i - 1 th worker should have been gone!
 						_.contains(expects, prevPid).should.equal(false);
-						emitter.emit(util.format('worker-%d-warmup', ithSuccessor));
+						emitter.emit(util.format('worker-%d-listening', ithSuccessor));
 					});
 
 					return {

--- a/test/worker-test.js
+++ b/test/worker-test.js
@@ -48,6 +48,7 @@ describe('worker', function(){
 						'createServer': require('http').createServer,
 						'app': app,
 						'port': port,
+                        'warmUpPort': port + 1,
 						'configureApp': function(app){
 							configured = true;
 						},


### PR DESCRIPTION
~ warmup for each worker now uses an intermediate server listening to 'warmup port' till warmup function is completed
~ then the worker starts the real server listening to the actual port
~ master awaits 'worker-%pid-listening' event
