### PR TITLE
~ fix failure of test case, where cache info got overwritten by concurre...

### DIFF
--- a/lib/cache-common.js
+++ b/lib/cache-common.js
@@ -45,9 +45,9 @@ var increment = 0,
 
 module.exports = {
 	
-	'domainPath': './cluster-cache-domain',
+	'domainPath': process.env.CACHE_DOMAIN_PATH || './cluster-cache-domain',
 	
-	'persistPath': './cluster-cache-persist',
+	'persistPath': process.env.CACHE_PERSIST_PATH || './cluster-cache-persist',
 	
 	'status': {
 		'success' : '1',

--- a/lib/cache-mgr.js
+++ b/lib/cache-mgr.js
@@ -269,7 +269,7 @@ module.exports = {
 
 	'afterServerStarted': function() { //'listening' listener
 	
-		logger.info('[cache] manager started');
+		logger.info('[cache] manager started, persistence:%j', persistPath);
 		
 		ensureDir(persistPath);
 		

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -133,11 +133,20 @@ module.exports = {
 
 		process.cluster2 = process.cluster2 || {};
 		process.cluster2.caching = options.enable;
+        
+        if(options.domainPath){
+            require('./cache-common').domainPath = options.domainPath;
+        }
+        if(options.persistPath){
+            require('./cache-common').persistPath = options.persistPath;
+        }
 
 		if(options.mode === 'standalone' && master){
 
 			master.fork(master.options, {
-				'CACHE_MANAGER': true
+				'CACHE_MANAGER': true,
+                'CACHE_DOMAIN_PATH': options.domainPath,
+                'CACHE_PERSIST_PATH': options.persistPath
 			});
 		}
 		else{

--- a/lib/index.js
+++ b/lib/index.js
@@ -161,7 +161,9 @@ module.exports = {
                 },
                 'cache': {
                     'enable': argv['cache.enable'] || true,
-                    'mode': argv['cache.mode'] || 'standalone' //a process will be allocated dedicated to it, otherwise crush that into master
+                    'mode': argv['cache.mode'] || 'standalone', //a process will be allocated dedicated to it, otherwise crush that into master
+                    'domainPath': argv['cache.domain-path'] || './cluster-cache-domain',
+                    'persistPath': argv['cache.persist-path'] || './cluster-cache-persist'
                 },
                 'gc': {
                     'monitor': argv['trace-gc'] || true,

--- a/lib/master.js
+++ b/lib/master.js
@@ -93,6 +93,7 @@ Master.prototype.initialize = function(proc, options){
 				return pipeline([
                         utils.pickAvailablePorts,
                         function(warmUpPorts){
+                            
                             return _.map(_.range(0, _this.noWorkers), function(ith){
                                 _this.options.warmUpPort = warmUpPorts.shift();
                                 _this.logger.info('[master] pick up warmup port:%d', _this.options.warmUpPort);
@@ -100,6 +101,7 @@ Master.prototype.initialize = function(proc, options){
                             });
                         },
                         function(){
+                            
                             return utils.markUpAfterAllListening(_this.emitter, 
                                 _.map(_this.puppets, function(p){
                                     return p.pid;

--- a/test/lib/cluster-cache-runtime.js
+++ b/test/lib/cluster-cache-runtime.js
@@ -51,7 +51,9 @@ listen({
     'configureApp': configureApp,
     'cache': {
         'enable': true,
-        'mode': 'standalone'
+        'mode': 'standalone',
+        'domainPath': '/tmp/cluster-cache-domain-' + process.pid,
+        'persistPath': '/tmp/cluster-cache-persist-' + process.pid
     },
     'ecv': {
         'mode': 'control',


### PR DESCRIPTION
...nt test cases

~ it's now configurable for both cache domain file path & persist path which allows test case to set differently
