### PR TITLE
Modified the order between configure monitor app and checking the ports

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -48,21 +48,6 @@ Master.prototype.initialize = function(proc, options){
 				assert.ok(_this.app);
 				assert.ok(_this.port);
 
-				when.all([
-					utils.rejectIfPortBusy('localhost', options.port), 
-					utils.rejectIfPortBusy('localhost', options.monPort),
-                    utils.rejectIfPortBusy('localhost', options.warmUpPort),
-					utils.rejectIfPortBusy('localhost', _this['debug.debugPort']),
-					utils.rejectIfPortBusy('localhost', _this['debug.webPort'])
-				])
-				.otherwise(function(error){
-
-					_this.logger.error('[master] one of the ports:%j we need has been occupied, please shutdown your program on that port; error:%j',
-						[options.port, options.monPort, _this['debug.debugPort'], _this['debug.webPort'], error]);
-
-					process.exit(-1);
-				});
-
 				//cache is 1st enabled, ahead of any worker process, ahead of master's monitor app configuration
 				//to allow cache service started earlier than where it's required.
 				require('./cache').enable(options.cache, _this);
@@ -74,7 +59,24 @@ Master.prototype.initialize = function(proc, options){
 				});
 
 				//monitor app could also be configured now, should return a value or promise.
-				return options.monConfigureApp(monApp);
+                return when.all([
+                    utils.rejectIfPortBusy('localhost', options.port),
+                    utils.rejectIfPortBusy('localhost', options.monPort),
+                    utils.rejectIfPortBusy('localhost', options.warmUpPort),
+                    utils.rejectIfPortBusy('localhost', _this['debug.debugPort']),
+                    utils.rejectIfPortBusy('localhost', _this['debug.webPort'])
+                ]).then(function (ports) {
+                    return options.monConfigureApp(monApp);
+                }, function (error) {
+                    _this.logger.error('[master] one of the ports:%j we need has been occupied, please shutdown your program on that port; error:%j', [
+                        options.port, 
+                        options.monPort, 
+                        _this['debug.debugPort'], 
+                        _this['debug.webPort'], 
+                        error
+                    ]);
+                    process.exit(-1);
+                });
 			},
 			'warmUp': function(){
 

--- a/test/cluster-cache-test.js
+++ b/test/cluster-cache-test.js
@@ -63,8 +63,9 @@ describe('Cache Performance Test', function () {
     });
 
     describe('# 90% read, %10 write', function () {
+        this.timeout(10000);
         var tasks = [];
-        for (var i=0; i<200; i++) {
+        for (var i=0; i<20; i++) {
             if (i % 10 === 0) {
                 tasks.push(writeTask);
             }else {
@@ -84,8 +85,9 @@ describe('Cache Performance Test', function () {
     });
 
     describe('# 50% read, 50% write', function () {
+        this.timeout(10000);
         var tasks = [];
-        for (var i=0; i<200; i++) {
+        for (var i=0; i<20; i++) {
             if (i % 10 < 5) {
                 tasks.push(writeTask);
             }else {
@@ -105,8 +107,9 @@ describe('Cache Performance Test', function () {
     });
 
     describe('# 10% read, 90% write', function () {
+        this.timeout(10000);
         var tasks = [];
-        for (var i=0; i<200; i++) {
+        for (var i=0; i<20; i++) {
             if (i % 10 < 9) {
                 tasks.push(writeTask);
             }else {

--- a/test/cluster-cache-test.js
+++ b/test/cluster-cache-test.js
@@ -38,6 +38,7 @@ describe('Cache Performance Test', function () {
     };
 
     before(function (done) {
+        this.timeout(10000);
         var token = 't-' + Date.now();
         utils.pickAvailablePorts(9090, 9190, 2).then(function (ports) {
             port = ports[0];

--- a/test/lib/cluster-cache-runtime.js
+++ b/test/lib/cluster-cache-runtime.js
@@ -45,7 +45,7 @@ function configureApp() {
 
 //console.log('aaa: ' + process.env.port);
 listen({
-    'noWorkers': 8,
+    'noWorkers': 2,
     'createServer': require('http').createServer,
     'app': app,
     'port': parseInt(process.env.port) || 9090,


### PR DESCRIPTION
The promise of configuring monitor app might be resolved while the checking ports is still running. Then master tend to start listening to the given port but it is possible that the port is under checking. I thought this is the cause for the CI failure. I also decreased number of workers and read/write times for the cache performance test because the CI machine is not that powerful and it will easily timeout for the high load. 
